### PR TITLE
Add `locationAriaLabel` to allow customizing location aria-label

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ ReactDOM.render(<App />, document.getElementById("app"));
 | locationClassName   | String\|Function | `'svg-map__location'` | CSS class of each `<path>`. The function parameters are the location object and the location index.              |
 | locationTabIndex    | String\|Function | `'0'`                 | Tabindex each `<path>`. The function parameters are the location object and the location index.                  |
 | locationRole        | String           | `'none'`              | ARIA role of each `<path>`.                                                                                      |
+| locationAriaLabel   | Function | `${location.name}` | aria-label of each location. The function parameters are the location object and the location index.            |
 | onLocationMouseOver | Function         |                       | Invoked when the user puts the mouse over a location.                                                            |
 | onLocationMouseOut  | Function         |                       | Invoked when the user puts the mouse out of a location.                                                          |
 | onLocationMouseMove | Function         |                       | Invoked when the user moves the mouse on a location.                                                             |
@@ -120,6 +121,7 @@ ReactDOM.render(<App />, document.getElementById("app"));
 | map                 | Object           | **required**          | Describe SVG map to display. See [maps section](#maps) for more details.                                                                 |
 | className           | String           | `'svg-map'`           | CSS class of `<svg>`.                                                                                                                    |
 | locationClassName   | String\|Function | `'svg-map__location'` | CSS class of each `<path>`. The function parameters are the location object and the location index.                                      |
+| locationAriaLabel   | Function | `${location.name}` | aria-label of each location. The function parameters are the location object and the location index.            |
 | selectedLocationIds | String[]         |                       | List of `id`s of the **initial** selected locations. It is used only when the component is mounted and is not synchronized when updated. |
 | onChange            | Function         |                       | Invoked when the user selects/deselects a location. The list of selected locations is passed as parameter.                               |
 | onLocationMouseOver | Function         |                       | Invoked when the user puts the mouse over a location.                                                                                    |
@@ -166,6 +168,7 @@ ReactDOM.render(<App />, document.getElementById("app"));
 | map                 | Object           | **required**          | Describe SVG map to display. See [maps section](#maps) for more details.                                                       |
 | className           | String           | `'svg-map'`           | CSS class of `<svg>`.                                                                                                          |
 | locationClassName   | String\|Function | `'svg-map__location'` | CSS class of each `<path>`. The function parameters are the location object and the location index.                            |
+| locationAriaLabel   | Function | `${location.name}` | aria-label of each location. The function parameters are the location object and the location index.            |
 | selectedLocationId  | String           |                       | `id` of the **initial** selected location. It is used only when the component is mounted and is not synchronized when updated. |
 | onChange            | Function         |                       | Invoked when the user selects a location. The selected location is passed as parameter.                                        |
 | onLocationMouseOver | Function         |                       | Invoked when the user puts the mouse over a location.                                                                          |

--- a/__tests__/__snapshots__/svg-map.test.js.snap
+++ b/__tests__/__snapshots__/svg-map.test.js.snap
@@ -75,7 +75,7 @@ exports[`SVGMap component Properties displays map with custom props 1`] = `
   </text>
   <path
     aria-checked="isLocationSelected"
-    aria-label="name0"
+    aria-label="name0-0"
     className="locationClassName"
     d="path0"
     id="id0"
@@ -92,7 +92,7 @@ exports[`SVGMap component Properties displays map with custom props 1`] = `
   />
   <path
     aria-checked="isLocationSelected"
-    aria-label="name1"
+    aria-label="name1-1"
     className="locationClassName"
     d="path1"
     id="id1"
@@ -109,7 +109,7 @@ exports[`SVGMap component Properties displays map with custom props 1`] = `
   />
   <path
     aria-checked="isLocationSelected"
-    aria-label="name2"
+    aria-label="name2-2"
     className="locationClassName"
     d="path2"
     id="id2"

--- a/__tests__/svg-map.test.js
+++ b/__tests__/svg-map.test.js
@@ -15,6 +15,7 @@ describe('SVGMap component', () => {
 		test('displays map with custom props', () => {
 			const eventHandler = () => 'eventHandler';
 			const isLocationSelected = () => 'isLocationSelected';
+			const locationAriaLabel = (location, index) => `${location.name}-${index}`
 			const component = renderer.create(
 				<SVGMap map={FakeMap}
 					className="className"
@@ -32,6 +33,7 @@ describe('SVGMap component', () => {
 					isLocationSelected={isLocationSelected}
 					childrenBefore={<text>childrenBefore</text>}
 					childrenAfter={<text>childrenAfter</text>}
+					locationAriaLabel={locationAriaLabel}
 				/>
 			);
 			const tree = component.toJSON();

--- a/src/checkbox-svg-map.jsx
+++ b/src/checkbox-svg-map.jsx
@@ -114,7 +114,6 @@ class CheckboxSVGMap extends React.Component {
 				onLocationBlur={this.props.onLocationBlur}
 				childrenBefore={this.props.childrenBefore}
 				childrenAfter={this.props.childrenAfter}
-
 			/>
 		);
 	}

--- a/src/checkbox-svg-map.jsx
+++ b/src/checkbox-svg-map.jsx
@@ -103,6 +103,7 @@ class CheckboxSVGMap extends React.Component {
 				locationTabIndex="0"
 				className={this.props.className}
 				locationClassName={this.props.locationClassName}
+				locationAriaLabel={this.props.locationAriaLabel}
 				isLocationSelected={this.isLocationSelected}
 				onLocationClick={this.handleLocationClick}
 				onLocationKeyDown={this.handleLocationKeyDown}
@@ -113,6 +114,7 @@ class CheckboxSVGMap extends React.Component {
 				onLocationBlur={this.props.onLocationBlur}
 				childrenBefore={this.props.childrenBefore}
 				childrenAfter={this.props.childrenAfter}
+
 			/>
 		);
 	}
@@ -136,6 +138,7 @@ CheckboxSVGMap.propTypes = {
 	}).isRequired,
 	className: PropTypes.string,
 	locationClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+	locationAriaLabel: PropTypes.func,
 	onLocationMouseOver: PropTypes.func,
 	onLocationMouseOut: PropTypes.func,
 	onLocationMouseMove: PropTypes.func,

--- a/src/radio-svg-map.jsx
+++ b/src/radio-svg-map.jsx
@@ -137,6 +137,7 @@ class RadioSVGMap extends React.Component {
 				locationRole="radio"
 				className={this.props.className}
 				locationClassName={this.props.locationClassName}
+				locationAriaLabel={this.props.locationAriaLabel}
 				isLocationSelected={this.isLocationSelected}
 				onLocationClick={this.handleLocationClick}
 				onLocationKeyDown={this.handleLocationKeyDown}
@@ -171,6 +172,7 @@ RadioSVGMap.propTypes = {
 	}).isRequired,
 	className: PropTypes.string,
 	locationClassName: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+	locationAriaLabel: PropTypes.func,
 	onLocationMouseOver: PropTypes.func,
 	onLocationMouseOut: PropTypes.func,
 	onLocationMouseMove: PropTypes.func,

--- a/src/svg-map.jsx
+++ b/src/svg-map.jsx
@@ -20,7 +20,7 @@ function SVGMap(props) {
 						className={typeof props.locationClassName === 'function' ? props.locationClassName(location, index) : props.locationClassName}
 						tabIndex={typeof props.locationTabIndex === 'function' ? props.locationTabIndex(location, index) : props.locationTabIndex}
 						role={props.locationRole}
-						aria-label={location.name}
+						aria-label={typeof props.locationAriaLabel === 'undefined' ? location.name : props.locationAriaLabel(location, index)}
 						aria-checked={props.isLocationSelected && props.isLocationSelected(location, index)}
 						onMouseOver={props.onLocationMouseOver}
 						onMouseOut={props.onLocationMouseOut}
@@ -66,6 +66,7 @@ SVGMap.propTypes = {
 	onLocationFocus: PropTypes.func,
 	onLocationBlur: PropTypes.func,
 	isLocationSelected: PropTypes.func,
+	locationAriaLabel: PropTypes.func,
 
 	// Slots
 	childrenBefore: PropTypes.node,


### PR DESCRIPTION
This is related to accessibility.

Screen readers read the aria-labels, thus now they read 'location.name' only - other than the information we want to convey at each location

Tried to use 'aria-describedby' attribute to point to a tooltip to solve this issue, but it doesn't work on some of the browsers (e.g. Safari on IOS 12).

Supporting custom location aria-labels is a better solution. 